### PR TITLE
Added validation for IPv4/v6 address.

### DIFF
--- a/google_cloud_dns/rootfs/etc/services.d/google_cloud_dns/run
+++ b/google_cloud_dns/rootfs/etc/services.d/google_cloud_dns/run
@@ -133,7 +133,7 @@ do
     [[ ${CONFIG_IPV4} != *:/* ]] && IPV4=${CONFIG_IPV4} || IPV4=$(curl -s -m 10 "${CONFIG_IPV4}") || true
     [[ ${CONFIG_IPV6} != *:/* ]] && IPV6=${CONFIG_IPV6} || IPV6=$(curl -s -m 10 "${CONFIG_IPV6}") || true
 
-    if [ "${IPV4}" != '' ] && [ "${IPV4}" != "${LAST_IPV4}" ]
+    if [[ "${IPV4}" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]] && [ "${IPV4}" != "${LAST_IPV4}" ]
     then
         EXIT_CODE=0
         google_cloud_update_dns.sh set "${FQDN}" A "${IPV4}" || EXIT_CODE=${?}
@@ -147,7 +147,7 @@ do
         fi
     fi
 
-    if [ "${IPV6}" != '' ] && [ "${IPV6}" != "${LAST_IPV6}" ]
+    if [[ "${IPV6}" =~ ^([0-9a-fA-F]{0,4}:){1,7}[0-9a-fA-F]{0,4}$ ]] && [ "${IPV6}" != "${LAST_IPV6}" ]
     then
         EXIT_CODE=0
         google_cloud_update_dns.sh set "${FQDN}" AAAA "${IPV6}" || EXIT_CODE=${?}


### PR DESCRIPTION
I've done some debugging and found out that sometimes curl req to https://api.ipify.org/ returns "Bad gateway" instead of a public IP address and these cause deletion of the resource record.